### PR TITLE
Add static factor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2913,6 +2913,12 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3017,6 +3023,18 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.25.9",
@@ -3667,6 +3685,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4219,7 +4249,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -9,7 +9,18 @@
     <div class="text-right">
       Expected Time
     </div>
-    <div class="col-span-2 text-right">
+    <template v-if="settingsStore.settings.useFactor">
+      <div class="text-right">
+        Factorized Expected Time
+      </div>
+    </template>
+    <div
+      class="col-span-2 text-right"
+      :class="{
+        'col-span-1': settingsStore.settings.useFactor,
+        'col-span-2': !settingsStore.settings.useFactor,
+      }"
+    >
       Standard Deviation of Time
     </div>
   </div>
@@ -23,6 +34,7 @@
       v-model:most-likely="activity.mostLikely"
       v-model:pessimistic="activity.pessimistic"
       v-model:expected-time="activity.expectedTime"
+      v-model:factorized-expected-time="activity.factorizedExpectedTime"
       v-model:standard-deviation-of-time="activity.standardDeviationOfTime"
       :activity-id="activity.id"
       :can-delete="canDelete"
@@ -42,6 +54,11 @@
     <div class="drac-text-semibold lg:text-right">
       <span class="lg:hidden">Total expected time: </span>{{ total.expectedTime }}
     </div>
+    <template v-if="settingsStore.settings.useFactor">
+      <div class="drac-text-semibold lg:text-right">
+        <span class="lg:hidden">Factorized total expected time: </span>{{ total.factorizedExpectedTime }}
+      </div>
+    </template>
     <div class="mt-4 lg:mt-0 lg:col-start-11 lg:col-span-2 text-right">
       <button
         type="button"

--- a/src/components/Import/Clipboard.vue
+++ b/src/components/Import/Clipboard.vue
@@ -19,7 +19,7 @@
 import type { ActivityInterface } from '@/interfaces/Activity';
 import useActivitiesStore from '@/stores/activities';
 import {
-  calcExpectedTime,
+  calcExpectedTime, calcFactorizedExpectedTime,
   calcStandardDeviationOfTime,
   getHighestActivityId,
   round,
@@ -50,6 +50,7 @@ const activityTemplate: ActivityInterface = {
   mostLikely: 0,
   pessimistic: 0,
   expectedTime: 0,
+  factorizedExpectedTime: 0,
   standardDeviationOfTime: 0,
 };
 
@@ -108,6 +109,7 @@ function tryParseActivitiesFromTable(html: Element): Array<ActivityInterface> {
 
     activity.expectedTime = round(calcExpectedTime(activity.optimistic, activity.mostLikely, activity.pessimistic));
     activity.standardDeviationOfTime = round(calcStandardDeviationOfTime(activity.pessimistic, activity.optimistic));
+    activity.factorizedExpectedTime = round(calcFactorizedExpectedTime(activity.expectedTime, get(settings).factor));
 
     if (_.isEqual(activityTemplate, activity)) {
       addError(`Unable to parse activity from row ${rowIndex}.`);
@@ -143,6 +145,7 @@ function tryParseActivitiesFromList(element: Element): Array<ActivityInterface> 
 
     activity.expectedTime = round(calcExpectedTime(activity.optimistic, activity.mostLikely, activity.pessimistic));
     activity.standardDeviationOfTime = round(calcStandardDeviationOfTime(activity.pessimistic, activity.optimistic));
+    activity.factorizedExpectedTime = round(calcFactorizedExpectedTime(activity.expectedTime, get(settings).factor));
 
     if (_.isEqual(activityTemplate, activity)) {
       addError(`Unable to parse activity from row ${itemIndex}.`);

--- a/src/components/Import/Clipboard.vue
+++ b/src/components/Import/Clipboard.vue
@@ -19,7 +19,8 @@
 import type { ActivityInterface } from '@/interfaces/Activity';
 import useActivitiesStore from '@/stores/activities';
 import {
-  calcExpectedTime, calcFactorizedExpectedTime,
+  calcExpectedTime,
+  calcFactorizedExpectedTime,
   calcStandardDeviationOfTime,
   getHighestActivityId,
   round,

--- a/src/components/Result/Table.vue
+++ b/src/components/Result/Table.vue
@@ -21,6 +21,11 @@
           <th class="pr-4 lg:pr-0">
             Expected Time
           </th>
+          <template v-if="settings.useFactor">
+            <th class="pr-4 lg:pr-0">
+              Factorized Expected Time
+            </th>
+          </template>
           <th class="pr-4 lg:pr-0">
             Standard Deviation of Time
           </th>
@@ -57,6 +62,9 @@
             {{ activity.pessimistic }}
           </td>
           <td>{{ activity.expectedTime }}</td>
+          <template v-if="settings.useFactor">
+            <td>{{ activity.factorizedExpectedTime }}</td>
+          </template>
           <td
             :class="[{
               'drac-text-white': !markHighStandardDeviationOfTime(activity.standardDeviationOfTime),
@@ -87,6 +95,11 @@
           <th class="px-2">
             {{ total.expectedTime }}
           </th>
+          <template v-if="settings.useFactor">
+            <th class="px-2">
+              {{ total.factorizedExpectedTime }}
+            </th>
+          </template>
         </tr>
       </tfoot>
     </table>

--- a/src/interfaces/Activity.ts
+++ b/src/interfaces/Activity.ts
@@ -5,5 +5,6 @@ export interface ActivityInterface extends Record<string, any> {
   mostLikely: number,
   pessimistic: number,
   expectedTime: number,
+  factorizedExpectedTime: number,
   standardDeviationOfTime: number,
 }

--- a/src/interfaces/Settings.ts
+++ b/src/interfaces/Settings.ts
@@ -14,6 +14,8 @@ export interface SettingsInterface {
   template: string,
   markHighStandardDeviationOfTime: boolean,
   standardDeviationOfTimeThreshold: number,
+  useFactor: boolean,
+  factor: number,
   storeSettings: boolean,
   storeActivities: boolean,
 }

--- a/src/interfaces/Total.ts
+++ b/src/interfaces/Total.ts
@@ -3,4 +3,5 @@ export interface Total {
   mostLikely: number
   pessimistic: number
   expectedTime: number
+  factorizedExpectedTime: number
 }

--- a/src/stores/activities.ts
+++ b/src/stores/activities.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import type { ActivityInterface } from '@/interfaces/Activity';
 import type { Total } from '@/interfaces/Total';
-import { round } from '@/utils';
+import {calcFactorizedExpectedTime, round} from '@/utils';
 
 interface State {
   activityId: number
@@ -18,6 +18,7 @@ export default defineStore('activities', {
       mostLikely: 0,
       pessimistic: 0,
       expectedTime: 0,
+      factorizedExpectedTime: 0,
       standardDeviationOfTime: 0,
     }],
   }),
@@ -30,12 +31,14 @@ export default defineStore('activities', {
       let mostLikely = 0;
       let pessimistic = 0;
       let expectedTime = 0;
+      let factorizedExpectedTime = 0;
 
       this.activities.forEach((activity) => {
         optimistic += activity.optimistic;
         mostLikely += activity.mostLikely;
         pessimistic += activity.pessimistic;
         expectedTime += activity.expectedTime;
+        factorizedExpectedTime += activity.factorizedExpectedTime;
       });
 
       return {
@@ -43,6 +46,7 @@ export default defineStore('activities', {
         mostLikely: round(mostLikely),
         pessimistic: round(pessimistic),
         expectedTime: round(expectedTime),
+        factorizedExpectedTime: round(factorizedExpectedTime),
       };
     },
   },
@@ -56,6 +60,7 @@ export default defineStore('activities', {
         mostLikely: 0,
         pessimistic: 0,
         expectedTime: 0,
+        factorizedExpectedTime: 0,
         standardDeviationOfTime: 0,
       });
     },
@@ -66,6 +71,11 @@ export default defineStore('activities', {
 
       const index = this.activities.findIndex((activity) => activity.id === activityId);
       this.activities.splice(index, 1);
+    },
+    recalculateFactorizedExpectedTime(factor: number): void {
+      this.activities.forEach((activity) => {
+        activity.factorizedExpectedTime = round(calcFactorizedExpectedTime(activity.expectedTime, factor));
+      })
     },
   },
 });

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -13,6 +13,8 @@ export default defineStore('settings', {
       template: '#title#: #optimistic# - #mostLikely# - #pessimistic# -> #expectedTime#',
       markHighStandardDeviationOfTime: false,
       standardDeviationOfTimeThreshold: 1,
+      useFactor: false,
+      factor: 1,
       storeSettings: false,
       storeActivities: false,
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,3 +55,7 @@ export function calcExpectedTime(optimistic: number, mostLikely: number, pessimi
 export function calcStandardDeviationOfTime(pessimistic: number, optimistic: number): number {
   return (pessimistic - optimistic) / 6;
 }
+
+export function calcFactorizedExpectedTime(expectedTime: number, factor: number): number {
+  return expectedTime * factor;
+}


### PR DESCRIPTION
This implements the option to multiply the expected time by a factor.
This is useful if you want to always add a certain amount for testing
or project management.

Resolves #9.

This is based upon #10.